### PR TITLE
Add role-based authentication

### DIFF
--- a/src/TDF/API.hs
+++ b/src/TDF/API.hs
@@ -7,6 +7,7 @@
 module TDF.API where
 
 import           Servant
+import           Servant.API.Experimental.Auth (AuthProtect)
 import           Data.Int (Int64)
 import           Data.Text (Text)
 import           Data.Time (UTCTime, Day)
@@ -41,13 +42,16 @@ type AdminAPI =
 
 type HealthAPI = Get '[JSON] HealthStatus
 
-type API =
-       "health"  :> HealthAPI
-  :<|> "parties" :> PartyAPI
+type ProtectedAPI =
+       "parties"  :> PartyAPI
   :<|> "bookings" :> BookingAPI
   :<|> "packages" :> PackageAPI
   :<|> "invoices" :> InvoiceAPI
   :<|> "admin"    :> AdminAPI
+
+type API =
+       "health" :> HealthAPI
+  :<|> AuthProtect "bearer-token" :> ProtectedAPI
 
 data HealthStatus = HealthStatus { status :: String, db :: String }
 

--- a/src/TDF/Auth.hs
+++ b/src/TDF/Auth.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+module TDF.Auth
+  ( AuthedUser(..)
+  , ModuleAccess(..)
+  , authContext
+  , hasModuleAccess
+  , moduleName
+  ) where
+
+import           Control.Monad.IO.Class     (liftIO)
+import qualified Data.ByteString.Lazy       as BL
+import           Data.List                  (foldl')
+import           Data.Set                   (Set)
+import qualified Data.Set                   as Set
+import           Data.Text                  (Text)
+import qualified Data.Text                  as T
+import qualified Data.Text.Encoding         as TE
+import           Database.Persist           (Entity(..), getBy, selectList, (==.))
+import           Database.Persist.Sql       (SqlPersistT, runSqlPool)
+import           Network.Wai                (Request, requestHeaders)
+import           Servant
+import           Servant.Server.Experimental.Auth (AuthHandler, mkAuthHandler)
+import           Servant.API.Experimental.Auth    (AuthProtect)
+
+import           TDF.DB                     (Env(..))
+import           TDF.Models
+
+-- | Enumeration of major application modules.
+data ModuleAccess
+  = ModuleCRM
+  | ModuleScheduling
+  | ModulePackages
+  | ModuleInvoicing
+  | ModuleAdmin
+  deriving (Eq, Ord, Show, Enum, Bounded)
+
+moduleName :: ModuleAccess -> Text
+moduleName ModuleCRM        = "CRM"
+moduleName ModuleScheduling = "Scheduling"
+moduleName ModulePackages   = "Packages"
+moduleName ModuleInvoicing  = "Invoicing"
+moduleName ModuleAdmin      = "Admin"
+
+-- | Authenticated user with associated module access.
+data AuthedUser = AuthedUser
+  { auPartyId :: PartyId
+  , auRoles   :: [RoleEnum]
+  , auModules :: Set ModuleAccess
+  } deriving (Show, Eq)
+
+-- | Create the Servant auth context using the database environment.
+authContext :: Env -> Context '[AuthHandler Request AuthedUser]
+authContext env = mkAuthHandler (authWithToken env) :. EmptyContext
+
+-- | Check whether the user can access the given module.
+hasModuleAccess :: ModuleAccess -> AuthedUser -> Bool
+hasModuleAccess moduleTag AuthedUser{..} = moduleTag `Set.member` auModules
+
+-- Internal -----------------------------------------------------------------
+
+authWithToken :: Env -> Request -> Handler AuthedUser
+authWithToken env req = do
+  token <- either throw401 pure (extractToken req)
+  mUser <- liftIO . flip runSqlPool (envPool env) $ fetchUser token
+  case mUser of
+    Nothing   -> throw401 "Invalid or inactive token"
+    Just user -> pure user
+  where
+    throw401 msg = throwError err401 { errBody = BL.fromStrict (TE.encodeUtf8 msg) }
+
+fetchUser :: Text -> SqlPersistT IO (Maybe AuthedUser)
+fetchUser token = do
+  mToken <- getBy (UniqueApiToken token)
+  case mToken of
+    Nothing -> pure Nothing
+    Just (Entity _ tok)
+      | not (apiTokenActive tok) -> pure Nothing
+      | otherwise -> do
+          roles <- selectList [PartyRolePartyId ==. apiTokenPartyId tok, PartyRoleActive ==. True] []
+          let roleList = map (partyRoleRole . entityVal) roles
+              modules  = modulesForRoles roleList
+          pure $ Just AuthedUser
+            { auPartyId = apiTokenPartyId tok
+            , auRoles   = roleList
+            , auModules = modules
+            }
+
+modulesForRoles :: [RoleEnum] -> Set ModuleAccess
+modulesForRoles = foldl' (flip (Set.union . modulesForRole)) Set.empty
+
+modulesForRole :: RoleEnum -> Set ModuleAccess
+modulesForRole Admin      = Set.fromList [ModuleCRM, ModuleScheduling, ModulePackages, ModuleInvoicing, ModuleAdmin]
+modulesForRole Manager    = Set.fromList [ModuleCRM, ModuleScheduling, ModulePackages, ModuleInvoicing]
+modulesForRole Reception  = Set.fromList [ModuleCRM, ModuleScheduling]
+modulesForRole Accounting = Set.singleton ModuleInvoicing
+modulesForRole Engineer   = Set.singleton ModuleScheduling
+modulesForRole Teacher    = Set.singleton ModuleScheduling
+modulesForRole Artist     = Set.singleton ModulePackages
+modulesForRole Student    = Set.singleton ModuleScheduling
+modulesForRole Vendor     = Set.singleton ModulePackages
+modulesForRole Customer   = Set.singleton ModulePackages
+modulesForRole ReadOnly   = Set.singleton ModuleCRM
+
+extractToken :: Request -> Either Text Text
+extractToken req =
+  case lookup "Authorization" (requestHeaders req) of
+    Nothing   -> Left "Missing Authorization header"
+    Just hdr  -> parseHeader (TE.decodeUtf8' hdr)
+  where
+    parseHeader (Left _) = Left "Invalid Authorization header encoding"
+    parseHeader (Right txt) =
+      case T.words txt of
+        [scheme, value]
+          | T.toLower scheme == "bearer" -> Right value
+          | otherwise                    -> Left "Unsupported authorization scheme"
+        _ -> Left "Malformed Authorization header"
+type instance AuthServerData (AuthProtect "bearer-token") = AuthedUser

--- a/src/TDF/Models.hs
+++ b/src/TDF/Models.hs
@@ -100,6 +100,13 @@ instance ToJSON StockTxnReason
 instance FromJSON StockTxnReason
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+ApiToken
+    token            Text
+    partyId          PartyId
+    label            Text Maybe
+    active           Bool
+    UniqueApiToken   token
+    deriving Show Generic
 Party
     legalName        Text Maybe
     displayName      Text

--- a/src/TDF/Seed.hs
+++ b/src/TDF/Seed.hs
@@ -6,7 +6,7 @@ import           Database.Persist
 import           Database.Persist.Sql
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           Data.Time (getCurrentTime)
+import           Data.Time (UTCTime, getCurrentTime)
 import           TDF.Models
 
 -- Seed data from Diego's YAML (normalized)
@@ -68,7 +68,41 @@ seedAll = do
   let assets = ["Korg SV1","Prophet 08","Moog Subsequent 37","Gibson Ripper Bass","Model 1","SVT","Tone Hammer"]
   mapM_ (\a -> insertUnique (Asset Nothing a "Instrument" Nothing Nothing Nothing Nothing (Just "Studio") Nothing False Nothing True) >> pure ()) assets
 
+  -- Staff accounts + API tokens for authentication examples
+  _ <- ensureStaff now "TDF Admin" (Just "TDF Admin") Admin "admin-token"
+  _ <- ensureStaff now "Front Desk Manager" Nothing Manager "manager-token"
+  _ <- ensureStaff now "Reception" Nothing Reception "reception-token"
+  _ <- ensureStaff now "Accounting" Nothing Accounting "accounting-token"
+  _ <- ensureStaff now "Scheduling" Nothing Engineer "scheduling-token"
+  _ <- ensureStaff now "Packages" Nothing Customer "packages-token"
+
   pure ()
 
 slugify :: Text -> Text
 slugify = T.toLower . T.replace " " "-"
+
+ensureStaff :: UTCTime -> Text -> Maybe Text -> RoleEnum -> Text -> SqlPersistT IO (Key Party)
+ensureStaff now name mlegal role token = do
+  pid <- ensurePartyRecord now name mlegal
+  _ <- upsert (PartyRole pid role True) [PartyRoleActive =. True]
+  upsertToken token pid (Just (roleLabel role))
+  pure pid
+
+ensurePartyRecord :: UTCTime -> Text -> Maybe Text -> SqlPersistT IO (Key Party)
+ensurePartyRecord now name mlegal = do
+  existing <- selectFirst [PartyDisplayName ==. name] []
+  case existing of
+    Just (Entity pid _) -> pure pid
+    Nothing -> insert $ Party mlegal name False Nothing Nothing Nothing Nothing Nothing Nothing Nothing now
+
+upsertToken :: Text -> PartyId -> Maybe Text -> SqlPersistT IO ()
+upsertToken token pid label = do
+  mTok <- getBy (UniqueApiToken token)
+  case mTok of
+    Just (Entity tokId _) -> update tokId [ ApiTokenPartyId =. pid, ApiTokenActive =. True, ApiTokenLabel =. label ]
+    Nothing -> do
+      _ <- insert $ ApiToken token pid label True
+      pure ()
+
+roleLabel :: RoleEnum -> Text
+roleLabel = T.pack . show

--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -13,10 +13,13 @@ import           Data.Int (Int64)
 import           Data.Time (getCurrentTime, UTCTime, Day, utctDay)
 import           Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import           Text.Read (readMaybe)
 
 import           Servant
-import           Network.Wai (Application)
+import           Network.Wai (Application, Request)
+import qualified Data.ByteString.Lazy as BL
+import           Servant.Server.Experimental.Auth (AuthHandler)
 
 import           Database.Persist
 import           Database.Persist.Sql
@@ -27,11 +30,16 @@ import           TDF.DB
 import           TDF.Models
 import           TDF.DTO
 import           TDF.Seed (seedAll)
+import           TDF.Auth (AuthedUser(..), ModuleAccess(..), authContext, hasModuleAccess, moduleName)
 
 type AppM = ReaderT Env Handler
 
 mkApp :: Env -> Application
-mkApp env = serve (Proxy :: Proxy API) (hoistServer (Proxy :: Proxy API) (nt env) server)
+mkApp env =
+  let apiProxy = Proxy :: Proxy API
+      ctxProxy = Proxy :: Proxy '[AuthHandler Request AuthedUser]
+      ctx      = authContext env
+  in serveWithContext apiProxy ctx (hoistServerWithContext apiProxy ctxProxy (nt env) server)
 
 nt :: Env -> AppM a -> Handler a
 nt env x = runReaderT x env
@@ -39,30 +47,36 @@ nt env x = runReaderT x env
 server :: ServerT API AppM
 server =
        health
-  :<|> partyServer
-  :<|> bookingServer
-  :<|> packageServer
-  :<|> invoiceServer
-  :<|> adminServer
+  :<|> protectedServer
+
+protectedServer :: AuthedUser -> ServerT ProtectedAPI AppM
+protectedServer user =
+       partyServer user
+  :<|> bookingServer user
+  :<|> packageServer user
+  :<|> invoiceServer user
+  :<|> adminServer user
 
 -- Health
 health :: AppM TDF.API.HealthStatus
 health = pure (HealthStatus "ok" "ok")
 
 -- Parties
-partyServer :: ServerT PartyAPI AppM
-partyServer = listParties :<|> createParty :<|> partyById
+partyServer :: AuthedUser -> ServerT PartyAPI AppM
+partyServer user = listParties user :<|> createParty user :<|> partyById
   where
-    partyById pid = getParty pid :<|> updateParty pid :<|> addRole pid
+    partyById pid = getParty user pid :<|> updateParty user pid :<|> addRole user pid
 
-listParties :: AppM [PartyDTO]
-listParties = do
+listParties :: AuthedUser -> AppM [PartyDTO]
+listParties user = do
+  requireModule user ModuleCRM
   Env pool _ <- ask
   entities <- liftIO $ flip runSqlPool pool $ selectList [] [Asc PartyId]
   pure (map toPartyDTO entities)
 
-createParty :: PartyCreate -> AppM PartyDTO
-createParty req = do
+createParty :: AuthedUser -> PartyCreate -> AppM PartyDTO
+createParty user req = do
+  requireModule user ModuleCRM
   Env pool _ <- ask
   now <- liftIO getCurrentTime
   let p = Party
@@ -81,8 +95,9 @@ createParty req = do
   pid <- liftIO $ flip runSqlPool pool $ insert p
   pure $ toPartyDTO (Entity pid p)
 
-getParty :: Int64 -> AppM PartyDTO
-getParty pidI = do
+getParty :: AuthedUser -> Int64 -> AppM PartyDTO
+getParty user pidI = do
+  requireModule user ModuleCRM
   Env pool _ <- ask
   let pid = toSqlKey pidI :: Key Party
   mp <- liftIO $ flip runSqlPool pool $ getEntity pid
@@ -90,8 +105,9 @@ getParty pidI = do
     Nothing -> throwError err404
     Just ent -> pure (toPartyDTO ent)
 
-updateParty :: Int64 -> PartyUpdate -> AppM PartyDTO
-updateParty pidI req = do
+updateParty :: AuthedUser -> Int64 -> PartyUpdate -> AppM PartyDTO
+updateParty user pidI req = do
+  requireModule user ModuleCRM
   Env pool _ <- ask
   let pid = toSqlKey pidI :: Key Party
   liftIO $ flip runSqlPool pool $ do
@@ -112,10 +128,11 @@ updateParty pidI req = do
               , partyNotes            = maybe (partyNotes p) Just       (uNotes req)
               }
         replace pid p'
-  getParty pidI
+  getParty user pidI
 
-addRole :: Int64 -> Text -> AppM NoContent
-addRole pidI roleTxt = do
+addRole :: AuthedUser -> Int64 -> Text -> AppM NoContent
+addRole user pidI roleTxt = do
+  requireModule user ModuleAdmin
   Env pool _ <- ask
   let pid  = toSqlKey pidI :: Key Party
       role = parseRole roleTxt
@@ -130,11 +147,12 @@ addRole pidI roleTxt = do
         Nothing -> ReadOnly
 
 -- Bookings
-bookingServer :: ServerT BookingAPI AppM
-bookingServer = listBookings :<|> createBooking
+bookingServer :: AuthedUser -> ServerT BookingAPI AppM
+bookingServer user = listBookings user :<|> createBooking user
 
-listBookings :: AppM [BookingDTO]
-listBookings = do
+listBookings :: AuthedUser -> AppM [BookingDTO]
+listBookings user = do
+  requireModule user ModuleScheduling
   Env pool _ <- ask
   bs <- liftIO $ flip runSqlPool pool $ selectList [] [Desc BookingId]
   pure $ map toDTO bs
@@ -148,8 +166,9 @@ listBookings = do
       , notes     = bookingNotes b
       }
 
-createBooking :: CreateBookingReq -> AppM BookingDTO
-createBooking req = do
+createBooking :: AuthedUser -> CreateBookingReq -> AppM BookingDTO
+createBooking user req = do
+  requireModule user ModuleScheduling
   Env pool _ <- ask
   now <- liftIO getCurrentTime
   let status' = parseStatus (cbStatus req)
@@ -179,11 +198,12 @@ createBooking req = do
         Nothing -> Confirmed
 
 -- Packages
-packageServer :: ServerT PackageAPI AppM
-packageServer = listProducts :<|> createPurchase
+packageServer :: AuthedUser -> ServerT PackageAPI AppM
+packageServer user = listProducts user :<|> createPurchase user
 
-listProducts :: AppM [PackageProductDTO]
-listProducts = do
+listProducts :: AuthedUser -> AppM [PackageProductDTO]
+listProducts user = do
+  requireModule user ModulePackages
   Env pool _ <- ask
   ps <- liftIO $ flip runSqlPool pool $ selectList [PackageProductActive ==. True] [Asc PackageProductId]
   pure $ map toDTO ps
@@ -197,8 +217,9 @@ listProducts = do
       , ppPriceCents = packageProductPriceCents p
       }
 
-createPurchase :: PackagePurchaseReq -> AppM NoContent
-createPurchase req = do
+createPurchase :: AuthedUser -> PackagePurchaseReq -> AppM NoContent
+createPurchase user req = do
+  requireModule user ModulePackages
   Env pool _ <- ask
   now <- liftIO getCurrentTime
   let buyer = toSqlKey (buyerId req)   :: Key Party
@@ -223,11 +244,12 @@ createPurchase req = do
   pure NoContent
 
 -- Invoices
-invoiceServer :: ServerT InvoiceAPI AppM
-invoiceServer = listInvoices :<|> createInvoice
+invoiceServer :: AuthedUser -> ServerT InvoiceAPI AppM
+invoiceServer user = listInvoices user :<|> createInvoice user
 
-listInvoices :: AppM [InvoiceDTO]
-listInvoices = do
+listInvoices :: AuthedUser -> AppM [InvoiceDTO]
+listInvoices user = do
+  requireModule user ModuleInvoicing
   Env pool _ <- ask
   is <- liftIO $ flip runSqlPool pool $ selectList [] [Desc InvoiceId]
   pure $ map toDTO is
@@ -241,8 +263,9 @@ listInvoices = do
       , totalC    = invoiceTotalCents i
       }
 
-createInvoice :: CreateInvoiceReq -> AppM InvoiceDTO
-createInvoice req = do
+createInvoice :: AuthedUser -> CreateInvoiceReq -> AppM InvoiceDTO
+createInvoice user req = do
+  requireModule user ModuleInvoicing
   Env pool _ <- ask
   now <- liftIO getCurrentTime
   let day = utctDay now
@@ -272,11 +295,20 @@ createInvoice req = do
     }
 
 -- Admin (temporary)
-adminServer :: ServerT AdminAPI AppM
-adminServer = seedHandler
+adminServer :: AuthedUser -> ServerT AdminAPI AppM
+adminServer user = seedHandler user
 
-seedHandler :: AppM NoContent
-seedHandler = do
+seedHandler :: AuthedUser -> AppM NoContent
+seedHandler user = do
+  requireModule user ModuleAdmin
   Env pool _ <- ask
   liftIO $ flip runSqlPool pool seedAll
   pure NoContent
+
+requireModule :: AuthedUser -> ModuleAccess -> AppM ()
+requireModule user moduleTag
+  | hasModuleAccess moduleTag user = pure ()
+  | otherwise = throwError err403
+      { errBody = BL.fromStrict (TE.encodeUtf8 msg) }
+  where
+    msg = "Missing access to module: " <> moduleName moduleTag

--- a/tdf-hq.cabal
+++ b/tdf-hq.cabal
@@ -15,6 +15,7 @@ executable tdf-hq-exe
     TDF.Config
     TDF.DB
     TDF.DTO
+    TDF.Auth
     TDF.Models
     TDF.Seed
     TDF.Server


### PR DESCRIPTION
## Summary
- add bearer token authentication with an auth handler that resolves user roles into module permissions
- protect the API routes behind authentication and enforce module checks per endpoint
- seed demo API tokens for common roles and include the new auth module in the build configuration

## Testing
- `stack build` *(fails: command not found in container)*
- `cabal build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd686d6a88832bb6523203478e73f3