### PR TITLE
Make database reset optional

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,6 +2,7 @@
 module Main where
 
 import qualified Network.Wai.Handler.Warp as Warp
+import           Control.Monad            (when)
 import           Data.ByteString.Char8    (pack)
 import           Database.Persist.Sql     (SqlPersistT, rawExecute, runMigration, runSqlPool)
 
@@ -24,12 +25,17 @@ main :: IO ()
 main = do
   cfg  <- loadConfig
   pool <- makePool (pack (dbConnString cfg))
-  putStrLn "Resetting DB schema..."
-  runSqlPool resetSchema pool
+  if resetDb cfg
+    then do
+      putStrLn "Resetting DB schema..."
+      runSqlPool resetSchema pool
+    else
+      putStrLn "RESET_DB disabled, preserving existing schema."
   putStrLn "Running DB migrations..."
   runSqlPool runMigrations pool
-  putStrLn "Seeding initial data..."
-  runSqlPool seedAll pool
+  when (seedDatabase cfg) $ do
+    putStrLn "Seeding initial data..."
+    runSqlPool seedAll pool
   putStrLn ("Starting server on port " <> show (appPort cfg))
 
   let allowedOrigins =

--- a/config/default.env
+++ b/config/default.env
@@ -4,3 +4,5 @@ DB_USER=postgres
 DB_PASS=postgres
 DB_NAME=tdf_hq
 APP_PORT=8080
+RESET_DB=false
+SEED_DB=false

--- a/src/TDF/Config.hs
+++ b/src/TDF/Config.hs
@@ -1,16 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 module TDF.Config where
 
+import           Data.Char          (toLower)
+import           Data.Maybe         (fromMaybe)
 import           System.Environment (lookupEnv)
-import           Data.Maybe (fromMaybe)
 
 data AppConfig = AppConfig
-  { dbHost  :: String
-  , dbPort  :: String
-  , dbUser  :: String
-  , dbPass  :: String
-  , dbName  :: String
-  , appPort :: Int
+  { dbHost       :: String
+  , dbPort       :: String
+  , dbUser       :: String
+  , dbPass       :: String
+  , dbName       :: String
+  , appPort      :: Int
+  , resetDb      :: Bool
+  , seedDatabase :: Bool
   } deriving (Show)
 
 dbConnString :: AppConfig -> String
@@ -23,13 +26,29 @@ dbConnString cfg =
 
 loadConfig :: IO AppConfig
 loadConfig = do
-  h  <- get "DB_HOST" "127.0.0.1"
-  p  <- get "DB_PORT" "5432"
-  u  <- get "DB_USER" "postgres"
-  w  <- get "DB_PASS" "postgres"
-  d  <- get "DB_NAME" "tdf_hq"
-  ap <- get "APP_PORT" "8080"
+  h   <- get "DB_HOST" "127.0.0.1"
+  p   <- get "DB_PORT" "5432"
+  u   <- get "DB_USER" "postgres"
+  w   <- get "DB_PASS" "postgres"
+  d   <- get "DB_NAME" "tdf_hq"
+  ap  <- get "APP_PORT" "8080"
+  rdb <- get "RESET_DB" "false"
+  sdb <- get "SEED_DB" "false"
   pure AppConfig
-    { dbHost = h, dbPort = p, dbUser = u, dbPass = w, dbName = d, appPort = read ap }
+    { dbHost = h
+    , dbPort = p
+    , dbUser = u
+    , dbPass = w
+    , dbName = d
+    , appPort = read ap
+    , resetDb = asBool rdb
+    , seedDatabase = asBool sdb
+    }
   where
     get k def = fmap (fromMaybe def) (lookupEnv k)
+    asBool v = case fmap toLower v of
+      "true"  -> True
+      "1"     -> True
+      "yes"   -> True
+      "on"    -> True
+      _       -> False


### PR DESCRIPTION
## Summary
- add configuration flags to control database schema reset and seeding
- update server startup to preserve existing data when resets are disabled
- document new environment variables in the default configuration

## Rationale
Avoid wiping the database during routine `stack build` / `stack run` cycles while still enabling resets when explicitly requested.

## Testing
- stack build *(fails: stack not available in container environment)*

## Sample curl
- N/A

## Issues
- None

------
https://chatgpt.com/codex/tasks/task_e_68e9e591e3c0832bb7ed753e5e49be7f