### PR TITLE
Add admin user management endpoints

### DIFF
--- a/src/TDF/API/Admin.hs
+++ b/src/TDF/API/Admin.hs
@@ -9,13 +9,31 @@ import           Servant
 import           TDF.API.Types ( DropdownOptionCreate
                                 , DropdownOptionDTO
                                 , DropdownOptionUpdate
+                                , RoleDetailDTO
+                                , UserAccountCreate
+                                , UserAccountDTO
+                                , UserAccountUpdate
                                 )
+
+import           Data.Int      (Int64)
 
 type DropdownCategoryAPI =
        QueryParam "includeInactive" Bool :> Get '[JSON] [DropdownOptionDTO]
   :<|> ReqBody '[JSON] DropdownOptionCreate :> PostCreated '[JSON] DropdownOptionDTO
   :<|> Capture "optionId" Text :> ReqBody '[JSON] DropdownOptionUpdate :> Patch '[JSON] DropdownOptionDTO
 
+type UsersAPI =
+       QueryParam "includeInactive" Bool :> Get '[JSON] [UserAccountDTO]
+  :<|> ReqBody '[JSON] UserAccountCreate :> PostCreated '[JSON] UserAccountDTO
+  :<|> Capture "userId" Int64 :>
+        ( Get '[JSON] UserAccountDTO
+     :<|> ReqBody '[JSON] UserAccountUpdate :> Patch '[JSON] UserAccountDTO
+        )
+
+type RolesAPI = Get '[JSON] [RoleDetailDTO]
+
 type AdminAPI =
        "seed" :> Post '[JSON] NoContent
   :<|> "dropdowns" :> Capture "category" Text :> DropdownCategoryAPI
+  :<|> "users" :> UsersAPI
+  :<|> "roles" :> RolesAPI

--- a/src/TDF/API/Types.hs
+++ b/src/TDF/API/Types.hs
@@ -17,6 +17,8 @@ import           GHC.Generics (Generic)
 import           Network.HTTP.Media ((//))
 import           Servant.API  (Accept(..), MimeUnrender(..), OctetStream, PlainText)
 
+import           TDF.Models   (RoleEnum)
+
 data Page a = Page
   { items    :: [a]
   , page     :: Int
@@ -58,6 +60,49 @@ data DropdownOptionUpdate = DropdownOptionUpdate
 
 instance ToJSON DropdownOptionUpdate
 instance FromJSON DropdownOptionUpdate
+
+data RoleDetailDTO = RoleDetailDTO
+  { role    :: RoleEnum
+  , label   :: Text
+  , modules :: [Text]
+  } deriving (Show, Generic)
+
+instance ToJSON RoleDetailDTO
+instance FromJSON RoleDetailDTO
+
+data UserAccountDTO = UserAccountDTO
+  { userId    :: Int64
+  , partyId   :: Int64
+  , partyName :: Text
+  , username  :: Text
+  , active    :: Bool
+  , roles     :: [RoleEnum]
+  , modules   :: [Text]
+  } deriving (Show, Generic)
+
+instance ToJSON UserAccountDTO
+instance FromJSON UserAccountDTO
+
+data UserAccountCreate = UserAccountCreate
+  { uacPartyId  :: Int64
+  , uacUsername :: Text
+  , uacPassword :: Text
+  , uacActive   :: Maybe Bool
+  , uacRoles    :: Maybe [RoleEnum]
+  } deriving (Show, Generic)
+
+instance ToJSON UserAccountCreate
+instance FromJSON UserAccountCreate
+
+data UserAccountUpdate = UserAccountUpdate
+  { uauUsername :: Maybe Text
+  , uauPassword :: Maybe Text
+  , uauActive   :: Maybe Bool
+  , uauRoles    :: Maybe [RoleEnum]
+  } deriving (Show, Generic)
+
+instance ToJSON UserAccountUpdate
+instance FromJSON UserAccountUpdate
 
 data BandOptionsDTO = BandOptionsDTO
   { roles  :: [DropdownOptionDTO]

--- a/src/TDF/Auth.hs
+++ b/src/TDF/Auth.hs
@@ -8,6 +8,7 @@ module TDF.Auth
   , authContext
   , hasModuleAccess
   , moduleName
+  , modulesForRoles
   , loadAuthedUser
   ) where
 

--- a/src/TDF/ServerAdmin.hs
+++ b/src/TDF/ServerAdmin.hs
@@ -11,23 +11,30 @@ import           Control.Monad          (unless, when)
 import           Control.Monad.Except   (MonadError)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Reader   (MonadReader, asks)
+import           Crypto.BCrypt          (hashPasswordUsingPolicy, slowerBcryptHashingPolicy)
+import           Data.Foldable          (for_)
 import           Data.Maybe             (fromMaybe, isJust)
+import qualified Data.Set               as Set
 import           Data.Text              (Text)
 import qualified Data.Text              as T
+import qualified Data.Text.Encoding     as TE
 import           Data.Time              (getCurrentTime)
 import           Database.Persist       ( (==.), (!=.)
                                         , (=.)
                                         , Entity(..)
+                                        , Update
                                         , Key
                                         , SelectOpt(..)
                                         , selectFirst
                                         , selectList
+                                        , getBy
                                         , update
                                         , getEntity
                                         , getJustEntity
                                         , insert
+                                        , upsert
                                         )
-import           Database.Persist.Sql   (SqlPersistT, runSqlPool)
+import           Database.Persist.Sql   (SqlPersistT, fromSqlKey, runSqlPool, toSqlKey)
 import           Servant
 import           Web.PathPieces         (PathPiece, fromPathPiece, toPathPiece)
 
@@ -35,9 +42,28 @@ import           TDF.API.Admin          (AdminAPI)
 import           TDF.API.Types          ( DropdownOptionCreate(..)
                                         , DropdownOptionDTO(..)
                                         , DropdownOptionUpdate(..)
+                                        , RoleDetailDTO(..)
+                                        , UserAccountCreate(..)
+                                        , UserAccountDTO(..)
+                                        , UserAccountUpdate(..)
                                         )
-import           TDF.Auth               (AuthedUser, ModuleAccess(..), hasModuleAccess)
+import           TDF.Auth               ( AuthedUser
+                                        , ModuleAccess(..)
+                                        , hasModuleAccess
+                                        , moduleName
+                                        , modulesForRoles
+                                        )
 import           TDF.DB                 (Env(..))
+import           TDF.Models             ( Party(..)
+                                        , PartyId
+                                        , PartyRole(..)
+                                        , PartyRoleId
+                                        , RoleEnum
+                                        , UniqueCredentialUsername
+                                        , UniquePartyRole
+                                        , UserCredential(..)
+                                        , UserCredentialId
+                                        )
 import           TDF.ModelsExtra (DropdownOption(..))
 import qualified TDF.ModelsExtra as ME
 import           TDF.Seed               (seedAll)
@@ -49,7 +75,7 @@ adminServer
      )
   => AuthedUser
   -> ServerT AdminAPI m
-adminServer user = seedHandler :<|> dropdownRouter
+adminServer user = seedHandler :<|> dropdownRouter :<|> usersRouter :<|> rolesHandler
   where
     seedHandler = do
       ensureModule ModuleAdmin user
@@ -60,6 +86,25 @@ adminServer user = seedHandler :<|> dropdownRouter
            listOptions rawCategory
       :<|> createOption rawCategory
       :<|> updateOption rawCategory
+
+    usersRouter =
+           listUsers
+      :<|> createUser
+      :<|> userById
+
+    userById userId =
+           getUser userId
+      :<|> updateUser userId
+
+    rolesHandler = do
+      ensureModule ModuleAdmin user
+      pure (map roleDetail [minBound .. maxBound])
+
+    roleDetail role = RoleDetailDTO
+      { role    = role
+      , label   = T.pack (show role)
+      , modules = map moduleName (Set.toList (modulesForRoles [role]))
+      }
 
     listOptions rawCategory mIncludeInactive = do
       ensureModule ModuleAdmin user
@@ -142,12 +187,94 @@ adminServer user = seedHandler :<|> dropdownRouter
                   updates = if null baseUpdates
                     then []
                     else baseUpdates ++ [ME.DropdownOptionUpdatedAt =. now]
-              entity <- if null updates
-                then pure (Entity key option)
-                else withPool $ do
-                  update key updates
-                  getJustEntity key
-              pure (toDTO entity)
+      entity <- if null updates
+        then pure (Entity key option)
+        else withPool $ do
+          update key updates
+          getJustEntity key
+      pure (toDTO entity)
+
+    listUsers mIncludeInactive = do
+      ensureModule ModuleAdmin user
+      let includeInactive = fromMaybe False mIncludeInactive
+          filters = [UserCredentialActive ==. True | not includeInactive]
+      withPool $ do
+        creds <- selectList filters [Asc UserCredentialId]
+        mapM loadUserAccount creds
+
+    createUser UserAccountCreate{..} = do
+      ensureModule ModuleAdmin user
+      let trimmedUsername = T.strip uacUsername
+          trimmedPassword = T.strip uacPassword
+          activeValue     = fromMaybe True uacActive
+          partyKey        = toSqlKey uacPartyId :: PartyId
+      when (T.null trimmedUsername) $
+        throwError err400 { errBody = "Username is required" }
+      when (T.null trimmedPassword) $
+        throwError err400 { errBody = "Password is required" }
+      mParty <- withPool $ getEntity partyKey
+      case mParty of
+        Nothing -> throwError err404 { errBody = "Party not found" }
+        Just _  -> pure ()
+      conflict <- withPool $ getBy (UniqueCredentialUsername trimmedUsername)
+      when (isJust conflict) $
+        throwError err409 { errBody = "Username already exists" }
+      hashed <- liftIO (hashPasswordText trimmedPassword)
+      credId <- withPool $ insert UserCredential
+        { userCredentialPartyId      = partyKey
+        , userCredentialUsername     = trimmedUsername
+        , userCredentialPasswordHash = hashed
+        , userCredentialActive       = activeValue
+        }
+      for_ uacRoles $ \rolesList -> withPool $ setPartyRoles partyKey rolesList
+      withPool $ do
+        credEnt <- getJustEntity credId
+        loadUserAccount credEnt
+
+    getUser userId = do
+      ensureModule ModuleAdmin user
+      let credKey = toSqlKey userId :: UserCredentialId
+      mCred <- withPool $ getEntity credKey
+      case mCred of
+        Nothing       -> throwError err404
+        Just credEnt  -> withPool (loadUserAccount credEnt)
+
+    updateUser userId UserAccountUpdate{..} = do
+      ensureModule ModuleAdmin user
+      let credKey         = toSqlKey userId :: UserCredentialId
+          usernameUpdate  = T.strip <$> uauUsername
+      when (maybe False T.null usernameUpdate) $
+        throwError err400 { errBody = "Username must not be empty" }
+      passwordHash <- case uauPassword of
+        Nothing -> pure Nothing
+        Just rawPwd ->
+          let trimmed = T.strip rawPwd
+          in if T.null trimmed
+               then throwError err400 { errBody = "Password must not be empty" }
+               else Just <$> liftIO (hashPasswordText trimmed)
+      mCred <- withPool $ getEntity credKey
+      case mCred of
+        Nothing -> throwError err404
+        Just credEnt@(Entity _ cred) -> do
+          for_ usernameUpdate $ \newUsername ->
+            when (newUsername /= userCredentialUsername cred) $ do
+              conflict <- withPool $ getBy (UniqueCredentialUsername newUsername)
+              case conflict of
+                Just (Entity otherId _) | otherId /= credKey ->
+                  throwError err409 { errBody = "Username already exists" }
+                _ -> pure ()
+          let updates :: [Update UserCredential]
+              updates = concat
+                [ maybe [] (\newUsername -> [UserCredentialUsername =. newUsername]) usernameUpdate
+                , maybe [] (\flag -> [UserCredentialActive =. flag]) uauActive
+                , maybe [] (\hash -> [UserCredentialPasswordHash =. hash]) passwordHash
+                ]
+          when (not (null updates)) $
+            withPool $ update credKey updates
+          for_ uauRoles $ \rolesList -> withPool $ setPartyRoles (userCredentialPartyId cred) rolesList
+          withPool $ do
+            fresh <- getJustEntity credKey
+            loadUserAccount fresh
 
 withPool
   :: (MonadReader Env m, MonadIO m)
@@ -184,6 +311,44 @@ ensureModule
 ensureModule moduleTag user =
   unless (hasModuleAccess moduleTag user) $
     throwError err403 { errBody = "Missing required module access" }
+
+loadUserAccount :: Entity UserCredential -> SqlPersistT IO UserAccountDTO
+loadUserAccount credEnt@(Entity credId cred) = do
+  party <- getJustEntity (userCredentialPartyId cred)
+  roles <- selectList
+    [ PartyRolePartyId ==. userCredentialPartyId cred
+    , PartyRoleActive ==. True
+    ]
+    [Asc PartyRoleRole]
+  let roleList = map (partyRoleRole . entityVal) roles
+  pure UserAccountDTO
+    { userId    = fromSqlKey credId
+    , partyId   = fromSqlKey (entityKey party)
+    , partyName = partyDisplayName (entityVal party)
+    , username  = userCredentialUsername cred
+    , active    = userCredentialActive cred
+    , roles     = roleList
+    , modules   = map moduleName (Set.toList (modulesForRoles roleList))
+    }
+
+setPartyRoles :: PartyId -> [RoleEnum] -> SqlPersistT IO ()
+setPartyRoles partyKey rolesList = do
+  existing <- selectList [PartyRolePartyId ==. partyKey] []
+  let desired = Set.fromList rolesList
+  for_ (Set.toList desired) $ \role -> do
+    _ <- upsert (PartyRole partyKey role True) [PartyRoleActive =. True]
+    pure ()
+  for_ existing $ \(Entity roleId partyRole) ->
+    when (partyRoleActive partyRole && Set.notMember (partyRoleRole partyRole) desired) $
+      update roleId [PartyRoleActive =. False]
+
+hashPasswordText :: Text -> IO Text
+hashPasswordText pwd = do
+  let raw = TE.encodeUtf8 pwd
+  mHash <- hashPasswordUsingPolicy slowerBcryptHashingPolicy raw
+  case mHash of
+    Nothing   -> fail "Failed to hash password"
+    Just hash -> pure (TE.decodeUtf8 hash)
 
 toDTO :: Entity DropdownOption -> DropdownOptionDTO
 toDTO (Entity key option) = DropdownOptionDTO


### PR DESCRIPTION
## Summary
- extend the admin API with `/users` and `/roles` routes for managing credentials and viewing role metadata
- add shared DTOs for user accounts and role details and expose the role-to-module map in the auth layer
- implement list/create/update handlers for admin users, plus helpers to hash passwords and synchronise party roles

## Rationale
- the admin UI needs dedicated endpoints to create, edit, and inspect application users and their role-driven module access

## How to run
- `stack build`
- `stack run`

## Sample curl
```bash
curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/users

curl -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"uacPartyId":1,"uacUsername":"alice","uacPassword":"secret","uacRoles":["Manager"]}' \
     http://localhost:8080/admin/users

curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/roles
```

## Linked issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68ed76a26c7c832b93f4eacee9de92e0