### PR TITLE
Fix duplicate parties created by seed data

### DIFF
--- a/src/TDF/Seed.hs
+++ b/src/TDF/Seed.hs
@@ -28,7 +28,7 @@ seedAll = do
         , ("Juano Ledesma", Just "Juan Ledesma")
         ]
   mapM_ (\(disp, mlegal) -> do
-           _ <- insertUnique $ Party mlegal disp False Nothing Nothing Nothing Nothing Nothing Nothing Nothing now
+           _ <- ensurePartyRecord now disp mlegal
            pure ()
         ) artists
 
@@ -38,8 +38,9 @@ seedAll = do
         , ("Juan Ledesma", Nothing)
         ]
   mapM_ (\(disp, mlegal) -> do
-           pid <- insert $ Party mlegal disp False Nothing Nothing Nothing Nothing Nothing Nothing Nothing now
-           _ <- insertUnique (PartyRole pid Teacher True)
+           pid <- ensurePartyRecord now disp mlegal
+           _ <- upsert (PartyRole pid Teacher True)
+             [ PartyRoleActive =. True ]
            pure ()
         ) teachers
 


### PR DESCRIPTION
## Summary
- ensure artist records created by seeding reuse existing parties
- make teacher seeding idempotent by reusing parties and reactivating their role

## Rationale
- repeated seeding runs produced duplicate party rows and disabled teacher roles were not reactivated

## Testing
- Not run (stack CLI unavailable in environment)

## How to Run
- `stack setup`
- `stack build`
- `stack run`

## Sample curl
- N/A

## Linked Issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68ed7a767408832bae831d6b13f3c528