### PR TITLE
Enable automatic database seeding on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ set -a; source config/default.env; set +a
 stack setup
 stack build
 stack run
-# seed initial data (temporary endpoint)
-curl -X POST http://localhost:8080/admin/seed
+# database seeds now run automatically (set SEED_DB=false to skip)
 ```
 
 Server starts on `http://localhost:8080`.

--- a/config/default.env
+++ b/config/default.env
@@ -5,4 +5,4 @@ DB_PASS=postgres
 DB_NAME=tdf_hq
 APP_PORT=8080
 RESET_DB=false
-SEED_DB=false
+SEED_DB=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       DB_PASS: postgres
       DB_NAME: tdf_hq
       APP_PORT: "8080"
+      SEED_DB: "true"
     depends_on:
       db:
         condition: service_healthy

--- a/src/TDF/Config.hs
+++ b/src/TDF/Config.hs
@@ -33,7 +33,7 @@ loadConfig = do
   d   <- get "DB_NAME" "tdf_hq"
   ap  <- get "APP_PORT" "8080"
   rdb <- get "RESET_DB" "false"
-  sdb <- get "SEED_DB" "false"
+  sdb <- get "SEED_DB" "true"
   pure AppConfig
     { dbHost = h
     , dbPort = p


### PR DESCRIPTION
## Summary
- default the SEED_DB flag to true so the application automatically persists its seed data on every build and run
- ensure docker-compose passes SEED_DB to the app container and document the new behavior in the README

## Rationale
- automatic seeding keeps required reference data available without manual intervention and prevents empty databases after rebuilds

## How to run
- `set -a; source config/default.env; set +a`
- `stack setup`
- `stack build`
- `stack run`

## Sample curl
- N/A (no new endpoints added)

## Linked issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68ed80b62678832ba315f483250b5fb6