### PR TITLE
Fix config imports for reset flags

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ import           Network.Wai.Middleware.Cors
                  , simpleHeaders
                  )
 
-import           TDF.Config     (appPort, dbConnString, loadConfig)
+import           TDF.Config     (appPort, dbConnString, loadConfig, resetDb, seedDatabase)
 import           TDF.DB         (Env(..), makePool)
 import           TDF.Models     (migrateAll)
 import           TDF.ModelsExtra (migrateExtra)


### PR DESCRIPTION
## Summary
- include resetDb and seedDatabase accessors in Main module imports
- ensure new configuration flags compile by exposing the record field functions

## Testing
- stack build *(fails: stack not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee4f4a631c832ba86c1aa4fec7cd21