### PR TITLE
Include git metadata when building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN stack --no-terminal --install-ghc setup && \
 COPY app app
 COPY src src
 COPY config config
+COPY .git .git
 
 # Build and export the binary
 RUN stack --no-terminal --install-ghc build --copy-bins --local-bin-path /out


### PR DESCRIPTION
## Summary
- copy the repository's git metadata into the Docker builder stage so gitrev can embed the commit hash during compilation

## Rationale
- without the .git directory inside the builder image, gitrev falls back to the placeholder value and `/version` reports "UNKNOWN"

## Testing
- not run (docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fd6fdc01b4832b822ff04164fd3297