### PR TITLE
Add unauthenticated seed endpoint guarded by header token

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ make clean    # stop and remove volumes
 
 Compose sets DB env for the app; the server listens on `localhost:8080`.
 
+To trigger the seed job without an admin session (e.g., for a remote staging
+deployment), send:
+
+```bash
+curl -X POST "$APP_BASE_URL/seed" -H "X-Seed-Token: ${SEED_TRIGGER_TOKEN:-tdf-bootstrap-seed}"
+```
+
+Set `SEED_TRIGGER_TOKEN` to a custom value to keep the endpoint protected. An
+empty value disables the unauthenticated seed route entirely.
+
 
 ---
 

--- a/config/default.env
+++ b/config/default.env
@@ -6,3 +6,4 @@ DB_NAME=tdf_hq
 APP_PORT=8080
 RESET_DB=false
 SEED_DB=true
+SEED_TRIGGER_TOKEN=tdf-bootstrap-seed

--- a/src/TDF/API.hs
+++ b/src/TDF/API.hs
@@ -55,6 +55,8 @@ type MetaAPI = "version" :> Get '[JSON] VersionJSON
 
 type LoginAPI = ReqBody '[JSON] LoginRequest :> Post '[JSON] LoginResponse
 
+type SeedAPI = Header "X-Seed-Token" Text :> Post '[JSON] NoContent
+
 type ProtectedAPI =
        "parties"  :> PartyAPI
   :<|> "bookings" :> BookingAPI
@@ -73,6 +75,7 @@ type API =
        "health" :> HealthAPI
   :<|> "login"  :> LoginAPI
   :<|> MetaAPI
+  :<|> "seed"   :> SeedAPI
   :<|> AuthProtect "bearer-token" :> ProtectedAPI
 
 data HealthStatus = HealthStatus { status :: String, db :: String }

--- a/src/TDF/Config.hs
+++ b/src/TDF/Config.hs
@@ -3,6 +3,8 @@ module TDF.Config where
 
 import           Data.Char          (toLower)
 import           Data.Maybe         (fromMaybe)
+import           Data.Text          (Text)
+import qualified Data.Text          as T
 import           System.Environment (lookupEnv)
 
 data AppConfig = AppConfig
@@ -14,6 +16,7 @@ data AppConfig = AppConfig
   , appPort      :: Int
   , resetDb      :: Bool
   , seedDatabase :: Bool
+  , seedTriggerToken :: Maybe Text
   } deriving (Show)
 
 dbConnString :: AppConfig -> String
@@ -26,14 +29,15 @@ dbConnString cfg =
 
 loadConfig :: IO AppConfig
 loadConfig = do
-  h   <- get "DB_HOST" "127.0.0.1"
-  p   <- get "DB_PORT" "5432"
-  u   <- get "DB_USER" "postgres"
-  w   <- get "DB_PASS" "postgres"
-  d   <- get "DB_NAME" "tdf_hq"
-  ap  <- get "APP_PORT" "8080"
-  rdb <- get "RESET_DB" "false"
-  sdb <- get "SEED_DB" "true"
+  h       <- get "DB_HOST" "127.0.0.1"
+  p       <- get "DB_PORT" "5432"
+  u       <- get "DB_USER" "postgres"
+  w       <- get "DB_PASS" "postgres"
+  d       <- get "DB_NAME" "tdf_hq"
+  ap      <- get "APP_PORT" "8080"
+  rdb     <- get "RESET_DB" "false"
+  sdb     <- get "SEED_DB" "true"
+  seedEnv <- lookupEnv "SEED_TRIGGER_TOKEN"
   pure AppConfig
     { dbHost = h
     , dbPort = p
@@ -43,6 +47,7 @@ loadConfig = do
     , appPort = read ap
     , resetDb = asBool rdb
     , seedDatabase = asBool sdb
+    , seedTriggerToken = mkSeedToken seedEnv
     }
   where
     get k def = fmap (fromMaybe def) (lookupEnv k)
@@ -52,3 +57,9 @@ loadConfig = do
       "yes"   -> True
       "on"    -> True
       _       -> False
+    mkSeedToken mVal =
+      case fmap (T.strip . T.pack) mVal of
+        Nothing -> Just defaultSeed
+        Just txt | T.null txt -> Nothing
+                 | otherwise -> Just txt
+    defaultSeed = T.pack "tdf-bootstrap-seed"

--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -49,6 +49,7 @@ import           TDF.Models
 import qualified TDF.Models as M
 import           TDF.DTO
 import           TDF.Auth (AuthedUser(..), ModuleAccess(..), authContext, hasModuleAccess, moduleName, loadAuthedUser)
+import           TDF.Seed       (seedAll)
 import           TDF.ServerAdmin (adminServer)
 import           TDF.ServerExtra (bandsServer, inventoryServer, loadBandForParty, pipelinesServer, roomsServer, sessionsServer)
 import           TDF.ServerFuture (futureServer)
@@ -79,6 +80,7 @@ server =
        health
   :<|> login
   :<|> metaServer
+  :<|> seedTrigger
   :<|> protectedServer
 
 protectedServer :: AuthedUser -> ServerT ProtectedAPI AppM
@@ -152,6 +154,20 @@ metaServer = do
   let pkgVersion = showVersion BuildInfo.version
       gitValue   = gitSha <|> buildGitSha
   pure VersionJSON { version = pkgVersion, git = gitValue }
+
+seedTrigger :: Maybe Text -> AppM NoContent
+seedTrigger rawToken = do
+  Env{..} <- ask
+  let encode = BL.fromStrict . TE.encodeUtf8
+      missingHeader = throwError err401 { errBody = encode "Missing X-Seed-Token header" }
+      disabled = throwError err403 { errBody = encode "Seeding endpoint disabled" }
+      invalid = throwError err403 { errBody = encode "Invalid seed token" }
+  secret <- maybe disabled pure (seedTriggerToken envConfig)
+  token  <- maybe missingHeader (pure . T.strip) rawToken
+  when (T.null token) missingHeader
+  when (token /= secret) invalid
+  liftIO $ flip runSqlPool envPool seedAll
+  pure NoContent
 
 buildGitSha :: Maybe String
 buildGitSha = normalizeValue $(gitHash)


### PR DESCRIPTION
## Summary
- expose a `/seed` route that triggers the existing seed job when given a valid `X-Seed-Token`
- load the seed trigger token from a new `SEED_TRIGGER_TOKEN` env var (defaulting to `tdf-bootstrap-seed`, empty disables)
- document the new flow and include the token in the sample env file

## Testing
- stack build *(fails: command not found: stack)*

------
https://chatgpt.com/codex/tasks/task_e_6900d4116bd0832bbd5a935ef7a8a047