### PR TITLE
Fix missing AppConfig import for seed trigger

### DIFF
--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -44,6 +44,7 @@ import           Database.Persist.Postgresql ()
 
 import           TDF.API
 import           TDF.API.Types (RolePayload(..))
+import           TDF.Config (AppConfig(..))
 import           TDF.DB
 import           TDF.Models
 import qualified TDF.Models as M


### PR DESCRIPTION
## Summary
- import the AppConfig record fields so the seed trigger handler can read the configured token

## Rationale
- the server build failed because the seedTriggerToken accessor was not in scope

## Testing
- not run (stack binary unavailable in the execution environment)

## Runbook
1. `stack build`

## Sample curl
- N/A (no new endpoints)

## Issues
- None

------
https://chatgpt.com/codex/tasks/task_e_690176a47b6c832b81b65e4753b9ffd1