### PR TITLE
Fix pipeline card seeding helper type signature

### DIFF
--- a/src/TDF/Seed.hs
+++ b/src/TDF/Seed.hs
@@ -62,6 +62,9 @@ seedAll = do
         , (Mastering, "Skanka Fe - LP", Just "Skanka Fe", Just "v1", 10)
         , (Mastering, "El Bloque - Single", Just "El Bloque", Just "Approved", 20)
         ]
+      ensurePipelineCard
+        :: (ServiceKind, Text, Maybe Text, Maybe Text, Int)
+        -> SqlPersistT IO ()
       ensurePipelineCard (kind, titleTxt, artistTxt, stageTxt, sortOrder) = do
         existing <- selectFirst
           [ ME.PipelineCardServiceKind ==. kind


### PR DESCRIPTION
## Summary
- constrain the local ensurePipelineCard helper to SqlPersistT IO to avoid illegal equality constraints
- keep existing pipeline seeding behaviour unchanged

## Testing
- cabal build --enable-tests --enable-benchmarks all *(fails: cabal not installed in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_69018010e3f4832b96249ba21e53be61