### PR TITLE
Fix pipeline and trials equality constraints

### DIFF
--- a/src/TDF/Seed.hs
+++ b/src/TDF/Seed.hs
@@ -62,6 +62,9 @@ seedAll = do
         , (Mastering, "Skanka Fe - LP", Just "Skanka Fe", Just "v1", 10)
         , (Mastering, "El Bloque - Single", Just "El Bloque", Just "Approved", 20)
         ]
+      ensurePipelineCard
+        :: (ServiceKind, Text, Maybe Text, Maybe Text, Int)
+        -> SqlPersistT IO ()
       ensurePipelineCard (kind, titleTxt, artistTxt, stageTxt, sortOrder) = do
         existing <- selectFirst
           [ ME.PipelineCardServiceKind ==. kind

--- a/src/TDF/Trials/Server.hs
+++ b/src/TDF/Trials/Server.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}


### PR DESCRIPTION
## Summary
- constrain the local ensurePipelineCard helper to SqlPersistT IO to avoid illegal equality constraints
- keep existing pipeline seeding behaviour unchanged
- enable the TypeFamilies extension in the trials server so SqlBackend equality constraints typecheck

## Testing
- cabal build --enable-tests --enable-benchmarks all *(fails: cabal not installed in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_69018010e3f4832b96249ba21e53be61