### PR TITLE
Fix resource lookup type annotation

### DIFF
--- a/src/TDF/Seed.hs
+++ b/src/TDF/Seed.hs
@@ -62,6 +62,9 @@ seedAll = do
         , (Mastering, "Skanka Fe - LP", Just "Skanka Fe", Just "v1", 10)
         , (Mastering, "El Bloque - Single", Just "El Bloque", Just "Approved", 20)
         ]
+      ensurePipelineCard
+        :: (ServiceKind, Text, Maybe Text, Maybe Text, Int)
+        -> SqlPersistT IO ()
       ensurePipelineCard (kind, titleTxt, artistTxt, stageTxt, sortOrder) = do
         existing <- selectFirst
           [ ME.PipelineCardServiceKind ==. kind

--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -417,6 +417,7 @@ resolveResourcesForBooking service requested start end = do
 resolveRequestedResources :: [Text] -> SqlPersistT IO [Key Resource]
 resolveRequestedResources ids = fmap catMaybes $ mapM lookupResource ids
   where
+    lookupResource :: Text -> SqlPersistT IO (Maybe (Key Resource))
     lookupResource rid =
       case fromPathPiece rid of
         Nothing  -> pure Nothing

--- a/src/TDF/Trials/Server.hs
+++ b/src/TDF/Trials/Server.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}


### PR DESCRIPTION
## Summary
- add an explicit SqlPersistT IO type signature for the local lookupResource helper
- ensure resolveRequestedResources no longer generates illegal SqlBackend equality constraints during compilation

## Rationale
- cabal build currently fails because GHC infers an overly general type for lookupResource; the explicit signature keeps it within SqlPersistT IO

## Testing
- stack build *(fails: stack not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69018010e3f4832b96249ba21e53be61