### PR TITLE
Fix meta API wiring to reuse shared handler

### DIFF
--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -5,15 +5,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module TDF.Server where
 
 import           Control.Applicative ((<|>))
-import           Control.Monad (void, forM, forM_, when)
+import           Control.Monad (forM, forM_, void, when)
 import           Control.Monad.IO.Class (liftIO)
-import           Control.Monad.Reader (ReaderT, runReaderT, ask)
-import           Crypto.BCrypt (validatePassword)
+import           Control.Monad.Reader (ReaderT, ask, runReaderT)
+import           Control.Monad.Trans.Class (lift)
+import qualified Data.ByteString.Lazy as BL
 import           Data.Int (Int64)
 import           Data.List (find, foldl', nub)
 import qualified Data.Map.Strict as Map
@@ -25,16 +25,14 @@ import qualified Data.Text.Encoding as TE
 import           Data.Time (Day, UTCTime, fromGregorian, getCurrentTime, toGregorian, utctDay)
 import           Data.UUID (toText)
 import           Data.UUID.V4 (nextRandom)
+import           Crypto.BCrypt (validatePassword)
+import           Network.Wai (Request)
+import           Servant
+import           Servant.Server.Experimental.Auth (AuthHandler)
 import           Text.Printf (printf)
 import           Text.Read (readMaybe)
-
 import           Web.PathPieces (fromPathPiece, toPathPiece)
-
-import           Servant
-import           Network.Wai (Request)
-import qualified Data.ByteString.Lazy as BL
-import           Servant.Server.Experimental.Auth (AuthHandler)
-import           Control.Monad.Trans.Class (lift)
+import           Data.Proxy (Proxy (..))
 
 import           Database.Persist
 import           Database.Persist.Sql
@@ -146,12 +144,10 @@ createSessionToken pid uname = do
     Nothing -> createSessionToken pid uname
     Just _  -> pure token
 
-metaServer :: AppM VersionJSON
-metaServer = do
-  gitSha <- liftIO (firstJustM lookupNormalized commitEnvVars)
-  let pkgVersion = showVersion BuildInfo.version
-      gitValue   = gitSha <|> buildGitSha
-  pure VersionJSON { version = pkgVersion, git = gitValue }
+metaServer :: ServerT Meta.MetaAPI AppM
+metaServer = hoistServer metaProxy lift Meta.metaServer
+  where
+    metaProxy = Proxy :: Proxy Meta.MetaAPI
 
 seedTrigger :: Maybe Text -> AppM NoContent
 seedTrigger rawToken = do
@@ -166,30 +162,6 @@ seedTrigger rawToken = do
   when (token /= secret) invalid
   liftIO $ flip runSqlPool envPool seedAll
   pure NoContent
-
-buildGitSha :: Maybe String
-buildGitSha = normalizeValue $(gitHash)
-
-commitEnvVars :: [String]
-commitEnvVars =
-  [ "GIT_SHA"
-  , "SOURCE_COMMIT"
-  , "KOYEB_GIT_COMMIT"
-  , "RENDER_GIT_COMMIT"
-  , "VERCEL_GIT_COMMIT_SHA"
-  , "RAILWAY_GIT_COMMIT_HASH"
-  ]
-
-lookupNormalized :: String -> IO (Maybe String)
-lookupNormalized key = do
-  val <- lookupEnv key
-  pure (val >>= normalizeValue)
-
-normalizeValue :: String -> Maybe String
-normalizeValue =
-  nonEmpty . trim
-  where
-    metaProxy = Proxy :: Proxy Meta.MetaAPI
 
 -- Parties
 partyServer :: AuthedUser -> ServerT PartyAPI AppM


### PR DESCRIPTION
## Summary
- reuse the shared Meta.metaServer handlers inside `TDF.Server`
- drop the bespoke build-info helpers and clean up related imports

## Rationale
- keeps the metadata endpoints defined in one place and resolves the build failure from missing symbols

## Testing
- Not run (stack is unavailable in the container)

## How to Run
- `stack build`

## Sample curl
- Not applicable; no new endpoints were added

## Issues
- None


------
https://chatgpt.com/codex/tasks/task_e_6904e7a65c1c832bad4a5cf64d29ea06