### PR TITLE
Guard input list seeding endpoints

### DIFF
--- a/src/TDF/API.hs
+++ b/src/TDF/API.hs
@@ -35,10 +35,14 @@ type VersionAPI = "version" :> Get '[JSON] VersionInfo
 
 type InputListPublicAPI =
        "inventory" :> Get '[JSON] [Entity InventoryItem]
-  :<|> "inventory" :> "seed" :> Header "X-Seed-Token" Text :> Post '[JSON] NoContent
   :<|> "sessions" :> QueryParam "index" Int :> QueryParam "sessionId" Text :> Get '[JSON] [Entity InputListEntry]
-  :<|> "sessions" :> "seed" :> Header "X-Seed-Token" Text :> Post '[JSON] NoContent
   :<|> "sessions" :> "pdf" :> QueryParam "index" Int :> QueryParam "sessionId" Text :> Get '[OctetStream] (Headers '[Header "Content-Disposition" Text] BL.ByteString)
+
+type InputListSeedAPI =
+       "inventory" :> "seed" :> SeedAPI
+  :<|> "sessions" :> "seed" :> SeedAPI
+
+type InputListAPI = InputListPublicAPI :<|> InputListSeedAPI
 
 type PartyAPI =
        Get '[JSON] [PartyDTO]
@@ -92,7 +96,7 @@ type API =
   :<|> "login"  :> LoginAPI
   :<|> MetaAPI
   :<|> "seed"   :> SeedAPI
-  :<|> "input-list" :> InputListPublicAPI
+  :<|> "input-list" :> InputListAPI
   :<|> AuthProtect "bearer-token" :> ProtectedAPI
 
 data HealthStatus = HealthStatus { status :: String, db :: String }

--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -87,13 +87,17 @@ server =
 versionServer :: ServerT VersionAPI AppM
 versionServer = liftIO getVersionInfo
 
-inputListServer :: ServerT InputListPublicAPI AppM
-inputListServer =
-       listInventory
-  :<|> seedInventory
-  :<|> getSessionInputList
-  :<|> seedHQ
-  :<|> getSessionInputListPdf
+inputListServer :: ServerT InputListAPI AppM
+inputListServer = inputListPublicServer :<|> inputListSeedServer
+  where
+    inputListPublicServer =
+           listInventory
+      :<|> getSessionInputList
+      :<|> getSessionInputListPdf
+
+    inputListSeedServer =
+           seedInventory
+      :<|> seedHQ
 
 listInventory :: AppM [Entity InputList.InventoryItem]
 listInventory = do


### PR DESCRIPTION
## Summary
- move the input list seeding routes behind the shared SeedAPI so they require the X-Seed-Token header
- split the input list server into public read handlers and token-gated seeding handlers to prevent unauthenticated access

## Testing
- `stack build` *(fails: stack not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_69076403889c832b86822ed6368038d8