### PR TITLE
Fix session input list PDF title generation

### DIFF
--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -142,7 +142,7 @@ getSessionInputListPdf
   -> AppM (Headers '[Header "Content-Disposition" Text] BL.ByteString)
 getSessionInputListPdf mIndex mSessionId = do
   (Entity _ session, rows) <- resolveSessionInputData mIndex mSessionId
-  let title = fromMaybe (sessionService session <> " session") (sessionClientPartyRef session)
+  let title = fromMaybe (ME.sessionService session <> " session") (ME.sessionClientPartyRef session)
       latex = InputList.renderInputListLatex title rows
   pdfResult <- liftIO (InputList.generateInputListPdf latex)
   case pdfResult of


### PR DESCRIPTION
## Summary
- qualify the session accessor calls in the input list PDF handler so they resolve to the ModelsExtra definitions

## Rationale
- fix the compile error introduced when session accessors were moved into `TDF.ModelsExtra`

## Testing
- `stack build` *(fails locally: stack is not available in the container environment)*
- `cabal build --enable-tests --enable-benchmarks all` *(fails locally: cabal is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_69076f3f6954832b8a99ddf1a64d3974