### PR TITLE
Remove redundant persistent imports

### DIFF
--- a/src/TDF/Models.hs
+++ b/src/TDF/Models.hs
@@ -20,9 +20,7 @@ import           Data.Aeson (ToJSON, FromJSON)
 import           GHC.Generics (Generic)
 import           Data.Text (Text)
 import           Data.Time (UTCTime, Day)
-import           Database.Persist
 import           Database.Persist.TH
-import           Database.Persist.Sql (SqlBackend)
 
 -- Enums
 data ServiceKind = Recording | Mixing | Mastering | Rehearsal | Classes | EventProduction


### PR DESCRIPTION
## Summary
- remove unused persistent imports from `TDF.Models`

## Rationale
- silence `-Wunused-imports` warnings emitted during `stack build`

## Testing
- Not run (stack not available in CI image)

## Sample curl
- N/A

## Issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_6907a3ff6384832b98e7ea1635779806