### PR TITLE
tidy imports in models

### DIFF
--- a/src/TDF/Models.hs
+++ b/src/TDF/Models.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
-
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE GADTs #-}
@@ -20,9 +19,7 @@ import           Data.Aeson (ToJSON, FromJSON)
 import           GHC.Generics (Generic)
 import           Data.Text (Text)
 import           Data.Time (UTCTime, Day)
-import           Database.Persist
 import           Database.Persist.TH
-import           Database.Persist.Sql (SqlBackend)
 
 -- Enums
 data ServiceKind = Recording | Mixing | Mastering | Rehearsal | Classes | EventProduction


### PR DESCRIPTION
## Summary
- remove unused persistent imports from the models module
- tidy the language pragma block at the top of the file

## Testing
- not run (stack unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6907d8db39c8832baae5cfc8f259a5b5