### PR TITLE
Fix session helpers reference in Server

### DIFF
--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -142,7 +142,7 @@ getSessionInputListPdf
   -> AppM (Headers '[Header "Content-Disposition" Text] BL.ByteString)
 getSessionInputListPdf mIndex mSessionId = do
   (Entity _ session, rows) <- resolveSessionInputData mIndex mSessionId
-  let title = fromMaybe (sessionService session <> " session") (sessionClientPartyRef session)
+  let title = fromMaybe (ME.sessionService session <> " session") (ME.sessionClientPartyRef session)
       latex = InputList.renderInputListLatex title rows
   pdfResult <- liftIO (InputList.generateInputListPdf latex)
   case pdfResult of


### PR DESCRIPTION
## Summary
- qualify the session helper lookups when building session input list PDF titles

## Rationale
- resolve the missing identifier error raised by the build because the accessors live in `TDF.ModelsExtra`

## Testing
- cabal build --enable-tests --enable-benchmarks all *(fails: cabal not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908b85ba2cc832bb97e5c229243571a