### PR TITLE
Fix session accessor usage in Server

### DIFF
--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -142,7 +142,7 @@ getSessionInputListPdf
   -> AppM (Headers '[Header "Content-Disposition" Text] BL.ByteString)
 getSessionInputListPdf mIndex mSessionId = do
   (Entity _ session, rows) <- resolveSessionInputData mIndex mSessionId
-  let title = fromMaybe (sessionService session <> " session") (sessionClientPartyRef session)
+  let title = fromMaybe (ME.sessionService session <> " session") (ME.sessionClientPartyRef session)
       latex = InputList.renderInputListLatex title rows
   pdfResult <- liftIO (InputList.generateInputListPdf latex)
   case pdfResult of


### PR DESCRIPTION
## Summary
- qualify session accessor usage in `TDF.Server` so it matches the qualified `ModelsExtra` import

## Rationale
- fix the build failure caused by references to unqualified session accessors that are only exposed via `TDF.ModelsExtra`

## Testing
- Not run (environment lacks `cabal` and `stack` executables)

## How to Run
- `stack build`
- `stack exec tdf-hq-exe`

## Sample cURL
- N/A

## Linked Issues
- N/A

------
https://chatgpt.com/codex/tasks/task_e_6908ea2a4658832b9337f9e8ba7e5abe