### PR TITLE
docs(calendar): Calendar API contract (public vs staff)

### DIFF
--- a/docs/CalendarAPI.md
+++ b/docs/CalendarAPI.md
@@ -1,0 +1,43 @@
+# Calendar API (draft)
+
+Propuesta de endpoint para alimentar el calendario unificado del Domo.
+
+## GET /calendar
+Parámetros opcionales:
+- `type`: `Rental` | `Artistic` | `Family`
+- `status`: `Hold` | `Confirmed` | `Invoiced` | `Paid`
+
+Header opcional:
+- `X-Role: staff` → devuelve `title` y `status` completos. Sin header: modo público `free/busy`.
+
+### Respuesta (staff)
+```json
+[{
+  "title": "Verde70 – Rehearsal – 3h",
+  "start": "2025-11-05T14:00:00Z",
+  "end":   "2025-11-05T17:00:00Z",
+  "ctype": "Artistic",
+  "status": "Confirmed"
+}]
+```
+
+### Respuesta (público)
+```json
+[{
+  "title": null,
+  "start": "2025-11-05T14:00:00Z",
+  "end":   "2025-11-05T17:00:00Z",
+  "ctype": "Artistic",
+  "status": null
+}]
+```
+
+## Notas de implementación
+- Primera iteración puede ser mock o proxy a Google Calendar (calendarios "Domo – Rentals" y "Domo – Artístico").
+- Mantener contrato JSON estable para TDF-ui y TDF-mobile.
+- Agregar filtros por query param es opcional, pero recomendado.
+
+## Futuro
+- Persistir reservas en DB con `status` (Hold/Confirmed/Invoiced/Paid).
+- Webhook/cron de expiración de holds a 48h.
+- Cálculo de horas y mapeo a Revenue Tracker.


### PR DESCRIPTION
Adds a draft contract for a future GET /calendar endpoint to feed the unified calendar (UI/mobile).

- New: docs/CalendarAPI.md
- Modes: public free/busy vs staff details
- Optional filters: type, status

This keeps the contract stable while we wire real data (GCal/DB).