### PR TITLE
Filter session inventory assets for input list dropdowns

### DIFF
--- a/src/TDF/API.hs
+++ b/src/TDF/API.hs
@@ -34,7 +34,11 @@ type InputListEntry = ME.InputRow
 type VersionAPI = "version" :> Get '[JSON] VersionInfo
 
 type InputListPublicAPI =
-       "inventory" :> Get '[JSON] [Entity InventoryItem]
+       "inventory"
+         :> QueryParam "field" Text
+         :> QueryParam "sessionId" Text
+         :> QueryParam "channel" Int
+         :> Get '[JSON] [Entity InventoryItem]
   :<|> "inventory" :> "seed" :> Header "X-Seed-Token" Text :> Post '[JSON] NoContent
   :<|> "sessions" :> QueryParam "index" Int :> QueryParam "sessionId" Text :> Get '[JSON] [Entity InputListEntry]
   :<|> "sessions" :> "seed" :> Header "X-Seed-Token" Text :> Post '[JSON] NoContent

--- a/src/TDF/Handlers/InputList.hs
+++ b/src/TDF/Handlers/InputList.hs
@@ -4,6 +4,8 @@
 module TDF.Handlers.InputList
   ( InventoryItem
   , InputListEntry
+  , AssetField(..)
+  , parseAssetField
   , listInventoryDB
   , seedInventoryDB
   , seedHQDB
@@ -16,7 +18,9 @@ module TDF.Handlers.InputList
 
 import           Control.Applicative        ((<|>))
 import           Control.Exception          (IOException, catch)
+import           Control.Monad              (guard)
 import           Data.Char                  (isAlphaNum)
+import           Data.List                  (find)
 import qualified Data.Map.Strict            as Map
 import           Data.Maybe                 (mapMaybe)
 import           Data.Text                  (Text)
@@ -32,12 +36,29 @@ import           System.Directory           (createDirectoryIfMissing, removeFil
 import           System.Exit                (ExitCode(..))
 import           System.FilePath            ((</>))
 import           System.Process             (readProcessWithExitCode)
+import qualified Data.Set                   as Set
 
 import qualified TDF.ModelsExtra            as ME
 import           TDF.Seed                   (seedHolgerSession, seedInventoryAssets)
 
 type InventoryItem = ME.Asset
 type InputListEntry = ME.InputRow
+
+data AssetField
+  = AssetFieldMic
+  | AssetFieldPreamp
+  deriving (Eq, Show)
+
+parseAssetField :: Text -> Maybe AssetField
+parseAssetField raw =
+  case T.toLower (T.strip raw) of
+    "mic"         -> Just AssetFieldMic
+    "microphone"  -> Just AssetFieldMic
+    "pre"         -> Just AssetFieldPreamp
+    "preamp"      -> Just AssetFieldPreamp
+    "pre-amp"     -> Just AssetFieldPreamp
+    "preamplifier"-> Just AssetFieldPreamp
+    _             -> Nothing
 
 instance ToJSON (Entity InventoryItem) where
   toJSON (Entity key item) = object
@@ -69,8 +90,46 @@ instance ToJSON (Entity InputListEntry) where
     , "notes"          .= ME.inputRowNotes row
     ]
 
-listInventoryDB :: SqlPersistT IO [Entity InventoryItem]
-listInventoryDB = selectList [] [Asc ME.AssetName]
+listInventoryDB
+  :: Maybe AssetField
+  -> Maybe ME.SessionId
+  -> Maybe Int
+  -> SqlPersistT IO [Entity InventoryItem]
+listInventoryDB mField mSession mChannel = do
+  allAssets <- selectList [] [Asc ME.AssetName]
+  let activeAssets = filter (isAssetActive . entityVal) allAssets
+      fieldFiltered = maybe activeAssets (\field -> filter (matchesField field) activeAssets) mField
+  case (mField, mSession) of
+    (Just field, Just sessionId) -> do
+      rows <- loadLatestInputRows sessionId
+      let usedIds = Set.fromList (mapMaybe (rowAsset field) (map entityVal rows))
+          keepId  = currentChannelAsset field rows mChannel
+          available = filter (assetAvailable usedIds keepId) fieldFiltered
+      pure available
+    _ -> pure fieldFiltered
+  where
+    isAssetActive asset = ME.assetStatus asset == ME.Active
+
+    matchesField field (Entity _ item) =
+      let category = T.toLower (ME.assetCategory item)
+      in case field of
+           AssetFieldMic    -> "mic" `T.isInfixOf` category || "di" `T.isInfixOf` category
+           AssetFieldPreamp -> "pre" `T.isInfixOf` category
+
+    rowAsset field row =
+      case field of
+        AssetFieldMic    -> ME.inputRowMicId row
+        AssetFieldPreamp -> ME.inputRowPreampId row
+
+    currentChannelAsset field rows mChan = do
+      channelNum <- mChan
+      guard (channelNum >= 1)
+      row <- find ((== channelNum) . ME.inputRowChannelNumber) (map entityVal rows)
+      rowAsset field row
+
+    assetAvailable usedIds keepId (Entity key _) =
+      let inUse = Set.member key usedIds
+      in not inUse || Just key == keepId
 
 seedInventoryDB :: SqlPersistT IO ()
 seedInventoryDB = seedInventoryAssets

--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -16,7 +16,7 @@ import           Control.Monad.Trans.Class (lift)
 import           Data.Int (Int64)
 import           Data.List (find, foldl', nub)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
+import           Data.Maybe (catMaybes, fromMaybe, isJust, isNothing, mapMaybe)
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -95,10 +95,30 @@ inputListServer =
   :<|> seedHQ
   :<|> getSessionInputListPdf
 
-listInventory :: AppM [Entity InputList.InventoryItem]
-listInventory = do
+listInventory
+  :: Maybe Text
+  -> Maybe Text
+  -> Maybe Int
+  -> AppM [Entity InputList.InventoryItem]
+listInventory mFieldParam mSessionParam mChannelParam = do
+  parsedField <- case mFieldParam of
+    Nothing -> pure Nothing
+    Just rawField ->
+      case InputList.parseAssetField rawField of
+        Nothing    -> throwBadRequest "Unsupported field"
+        Just field -> pure (Just field)
+  sessionKey <- case mSessionParam of
+    Nothing   -> pure Nothing
+    Just raw  ->
+      case fromPathPiece raw of
+        Nothing -> throwBadRequest "Invalid sessionId"
+        Just k  -> pure (Just k)
+  when (isJust mChannelParam && isNothing sessionKey) $
+    throwBadRequest "channel requires sessionId"
+  when (maybe False (< 1) mChannelParam) $
+    throwBadRequest "channel must be greater than or equal to 1"
   Env{..} <- ask
-  liftIO $ flip runSqlPool envPool InputList.listInventoryDB
+  liftIO $ flip runSqlPool envPool (InputList.listInventoryDB parsedField sessionKey mChannelParam)
 
 seedInventory :: Maybe Text -> AppM NoContent
 seedInventory rawToken = do


### PR DESCRIPTION
## Summary
- add asset field parsing to input list inventory handling and filter results by field
- expose query parameters on the public inventory endpoint to scope assets by field, session, and channel
- validate request parameters in the server and omit items already assigned to other channels while keeping the current selection available

## Testing
- `stack build --fast` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_69075d287848832ba06b8679207657c3