### PR TITLE
Allow password change without username payload

### DIFF
--- a/src/TDF/API.hs
+++ b/src/TDF/API.hs
@@ -83,7 +83,7 @@ type PasswordResetAPI = ReqBody '[JSON] PasswordResetRequest :> Post '[JSON] NoC
 
 type PasswordResetConfirmAPI = ReqBody '[JSON] PasswordResetConfirmRequest :> Post '[JSON] LoginResponse
 
-type PasswordAPI = "change" :> ReqBody '[JSON] ChangePasswordRequest :> Post '[JSON] LoginResponse
+type PasswordAPI = Header "Authorization" Text :> "change" :> ReqBody '[JSON] ChangePasswordRequest :> Post '[JSON] LoginResponse
 
 type AuthV1API =
        "signup" :> SignupAPI

--- a/src/TDF/DTO.hs
+++ b/src/TDF/DTO.hs
@@ -230,7 +230,7 @@ data SignupRequest = SignupRequest
 instance FromJSON SignupRequest
 
 data ChangePasswordRequest = ChangePasswordRequest
-  { username        :: Text
+  { username        :: Maybe Text
   , currentPassword :: Text
   , newPassword     :: Text
   } deriving (Show, Generic)

--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -316,17 +316,18 @@ data PasswordChangeError
   | PasswordProfileError
   deriving (Eq, Show)
 
-changePassword :: ChangePasswordRequest -> AppM LoginResponse
-changePassword ChangePasswordRequest{..} = do
-  let usernameClean        = T.strip username
-      currentPasswordClean = T.strip currentPassword
+changePassword :: Maybe Text -> ChangePasswordRequest -> AppM LoginResponse
+changePassword mAuthHeader ChangePasswordRequest{..} = do
+  let currentPasswordClean = T.strip currentPassword
       newPasswordClean     = T.strip newPassword
-  when (T.null usernameClean) $ throwBadRequest "Username is required"
+      maybeUsernameClean   = T.strip <$> username
   when (T.null currentPasswordClean) $ throwBadRequest "Current password is required"
   when (T.null newPasswordClean) $ throwBadRequest "New password is required"
   when (T.length newPasswordClean < 8) $
     throwBadRequest "New password must be at least 8 characters"
   Env pool _ <- ask
+  usernameClean <- resolveUsername pool maybeUsernameClean mAuthHeader
+  when (T.null usernameClean) $ throwBadRequest "Username is required"
   result <- liftIO $ flip runSqlPool pool $
     runChangePassword usernameClean currentPasswordClean newPasswordClean
   case result of
@@ -338,6 +339,33 @@ changePassword ChangePasswordRequest{..} = do
       throwError err500 { errBody = BL.fromStrict (TE.encodeUtf8 "Failed to load user profile") }
     Right resp -> pure resp
   where
+    resolveUsername pool mUsername header =
+      case mUsername of
+        Just uname | not (T.null uname) -> pure uname
+        _ -> do
+          token <- case header >>= parseBearer . T.strip of
+            Nothing  -> throwBadRequest "Username is required"
+            Just tok -> pure tok
+          mResolved <- liftIO $ flip runSqlPool pool (lookupUsernameFromToken tok)
+          case fmap T.strip mResolved of
+            Nothing     -> throwError err401 { errBody = BL.fromStrict (TE.encodeUtf8 "Invalid or inactive session token") }
+            Just uname' -> pure uname'
+
+    parseBearer headerText =
+      case T.words headerText of
+        [scheme, value]
+          | T.toLower scheme == "bearer" -> Just value
+        [value] -> Just value
+        _       -> Nothing
+
+    lookupUsernameFromToken token = do
+      mUser <- loadAuthedUser token
+      case mUser of
+        Nothing -> pure Nothing
+        Just AuthedUser{..} -> do
+          mCred <- selectFirst [UserCredentialPartyId ==. auPartyId, UserCredentialActive ==. True] []
+          pure (fmap (userCredentialUsername . entityVal) mCred)
+
     runChangePassword
       :: Text
       -> Text


### PR DESCRIPTION
## Summary
- allow the change password endpoint to look up the username from the bearer token when the payload omits it
- accept payloads without a username field so the UI can send only password data

## Rationale
- the UI currently omits the username when requesting a password change, so the backend needs to infer the account from the authenticated token

## Testing
- `stack build` *(fails in container: command not found)*

## How to Run
1. `stack build`
2. `stack run`

## Sample curl
```bash
curl -X POST \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  http://localhost:8080/api/password/change \
  -d '{"currentPassword":"old","newPassword":"newerpass"}'
```

## Linked Issues
- None

------
https://chatgpt.com/codex/tasks/task_e_690a40d3bf70832b8851ff69b9a192f5