### PR TITLE
Fix change password token lookup

### DIFF
--- a/src/TDF/Server.hs
+++ b/src/TDF/Server.hs
@@ -346,7 +346,7 @@ changePassword mAuthHeader ChangePasswordRequest{..} = do
           token <- case header >>= parseBearer . T.strip of
             Nothing  -> throwBadRequest "Username is required"
             Just tok -> pure tok
-          mResolved <- liftIO $ flip runSqlPool pool (lookupUsernameFromToken tok)
+          mResolved <- liftIO $ flip runSqlPool pool (lookupUsernameFromToken token)
           case fmap T.strip mResolved of
             Nothing     -> throwError err401 { errBody = BL.fromStrict (TE.encodeUtf8 "Invalid or inactive session token") }
             Just uname' -> pure uname'


### PR DESCRIPTION
## Summary
- fix the change password username resolution to reuse the token extracted from the Authorization header

## Rationale
- resolves a compilation failure from referencing an out-of-scope variable when looking up the username from a session token

## Testing
- `stack build` *(fails in this container: `stack` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_690a4327d384832bab5caf4f289b1e3c