### PR TITLE
Avoid copying git metadata in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ COPY stack.yaml tdf-hq.cabal ./
 RUN stack --no-terminal --install-ghc setup && \
     stack --no-terminal --install-ghc build --only-dependencies
 
-# Copy sources
-COPY .git .git
+# Copy sources (git metadata is provided via build args when available)
 COPY app app
 COPY src src
 COPY config config


### PR DESCRIPTION
## Summary
- stop copying the `.git` directory into the builder stage so Docker builds work even when git metadata is unavailable

## Rationale
- remote build contexts (e.g. Render) may not include the `.git` directory, which caused the image build to fail when the Dockerfile tried to copy it

## How to run
- `stack build`

## Sample curl
- N/A (no new endpoints)

## Issues
- None

------
https://chatgpt.com/codex/tasks/task_e_690a5815caa0832b95d68595ce5fbe36