### PR TITLE
Fix CORS middleware type usage

### DIFF
--- a/src/TDF/Cors.hs
+++ b/src/TDF/Cors.hs
@@ -1,19 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 module TDF.Cors (corsPolicy) where
-import Network.Wai.Middleware.Cors
-import Network.HTTP.Types (Method)
-import Data.Maybe (fromMaybe)
-import System.Environment (lookupEnv)
-import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.ByteString.Char8 as BS
-import Data.Char (isSpace)
+
+import           Data.Char                      (isSpace)
+import qualified Data.ByteString.Char8          as BS
+import           Network.Wai                    (Middleware)
+import           Network.Wai.Middleware.Cors
+import           System.Environment             (lookupEnv)
 
 corsPolicy :: IO Middleware
 corsPolicy = do
   origins <- fmap (maybe ["http://localhost:5173","https://tdfui.pages.dev"] splitComma) (lookupEnv "ALLOWED_ORIGINS")
   let policy = simpleCorsResourcePolicy
-        { corsOrigins        = Just (map (\o -> (BS.pack o, True)) origins, True)
+        { corsOrigins        = Just (map BS.pack origins, True)
         , corsRequestHeaders = "authorization":"content-type":simpleHeaders
         , corsMethods        = "GET":"POST":"PATCH":"OPTIONS":simpleMethods
         }


### PR DESCRIPTION
## Summary
- import the `Middleware` type from `Network.Wai` in `TDF.Cors`
- fix the CORS policy to provide a list of origins without per-origin flags

## Testing
- stack --no-terminal build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f3e8516e8832ba0734ad19c622bea)