### PR TITLE
Fix cabal test suite configuration

### DIFF
--- a/tdf-hq.cabal
+++ b/tdf-hq.cabal
@@ -87,8 +87,6 @@ test-suite tdf-hq-test
   type:              exitcode-stdio-1.0
   hs-source-dirs:    test, src
   main-is:           Spec.hs
-  other-modules:
-    TDF.AuthSpec
   ghc-options:       -Wall
   default-language:  Haskell2010
   build-depends:


### PR DESCRIPTION
## Summary
- remove the outdated `TDF.AuthSpec` entry from the Cabal test-suite configuration so the build no longer references a missing module

## Rationale
- `cabal build --enable-tests --enable-benchmarks all` fails because the test suite declares a module that is not present; removing the stale reference lets Cabal compile the existing tests

## How to Run
1. stack build
2. stack test

## Sample curl
- N/A (no new endpoints introduced)

## Linked Issues
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4c007d88832bac7097a73cb41a49)